### PR TITLE
feat: add support for row layout in generic empty state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.0.33",
+    "version": "0.0.34",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "0.0.33",
+            "version": "0.0.34",
             "license": "ISC",
             "dependencies": {
                 "sass": "^1.56.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "v0.0.32",
+    "version": "0.0.33",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "v0.0.32",
+            "version": "0.0.33",
             "license": "ISC",
             "dependencies": {
                 "sass": "^1.56.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.0.34",
+    "version": "v0.0.32",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "0.0.34",
+            "version": "v0.0.32",
             "license": "ISC",
             "dependencies": {
                 "sass": "^1.56.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.0.34",
+    "version": "0.0.34-beta-1",
     "description": "Supporting common component library",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.0.34-beta-1",
+    "version": "0.0.35",
     "description": "Supporting common component library",
     "main": "dist/index.js",
     "scripts": {

--- a/src/Common/EmptyState/GenericEmptyState.tsx
+++ b/src/Common/EmptyState/GenericEmptyState.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 import AppNotDeployed from '../../Assets/Img/app-not-deployed.png'
 import { GenericEmptyStateType, ImageType } from '../Types'
 
@@ -17,12 +17,15 @@ function GenericEmptyState({
     imageClassName,
     children,
     SvgImage,
-    noImage
+    noImage,
+    layout = 'column',
+    contentClassName = ''
 }: GenericEmptyStateType): JSX.Element {
+    const isRowLayout = layout === 'row';
     
     return (
         <div
-            className={`flex column empty-state ${classname ? classname : ''}`}
+            className={`flex ${isRowLayout ? 'dc__gap-32' : 'column dc__gap-20'} empty-state ${classname ? classname : ''}`}
             style={styles}
             data-testid="generic-empty-state"
             {...(heightToDeduct >= 0 && { style: { ...styles, height: `calc(100vh - ${heightToDeduct}px)` } })}
@@ -32,11 +35,13 @@ function GenericEmptyState({
                 width={imageType === ImageType.Medium ? '200' : '250'}
                 height={imageType === ImageType.Medium ? '160' : '200'}
                 alt="empty-state"
-            /> : <SvgImage/>}
-            <h4 className="title fw-6 cn-9 mb-8">{title}</h4>
-            {subTitle && <p className="subtitle">{subTitle}</p>}
-            {isButtonAvailable && renderButton()}
-              {children}
+            /> : <SvgImage />}
+            <div className={`flex column dc__gap-10 dc__mxw-300 ${isRowLayout ? 'dc__align-start' : ''} ${contentClassName}`}>
+                <h4 className="title fw-6 cn-9 mt-0 mb-0">{title}</h4>
+                {subTitle && <p className={`subtitle ${isRowLayout ? 'subtitle--text-start' : ''}`}>{subTitle}</p>}
+                {isButtonAvailable && renderButton()}
+                {children}
+            </div>
         </div>
     )
 }

--- a/src/Common/EmptyState/emptyState.scss
+++ b/src/Common/EmptyState/emptyState.scss
@@ -21,17 +21,19 @@
     }
     .subtitle {
         font-size: 13px;
-        width: 300px;
         font-weight: 400;
         text-align: center;
         line-height: 1.5;
-        margin-bottom: 20px;
+        margin-bottom: 6px;
+
+        &--text-start {
+            text-align: start;
+        }
     }
     .cta {
         height: 36px;
     }
     p {
-        width: 300px;
         text-align: center;
         font-size: 13px;
         color: var(--N700);

--- a/src/Common/Types.ts
+++ b/src/Common/Types.ts
@@ -92,6 +92,11 @@ export interface GenericEmptyStateType {
     imageClassName?: string
     children?: ReactNode
     noImage?: boolean
+    /**
+     * @default 'column'
+     */
+    layout?: 'row' | 'column'
+    contentClassName?: string
 }
 
 export enum ImageType {


### PR DESCRIPTION
 Add support for row & column layout in the `GenericEmptyState` component