### PR TITLE
Fix max-width for scanVulnerabilities Table cells

### DIFF
--- a/src/Common/Security/scanVulnerabilities.css
+++ b/src/Common/Security/scanVulnerabilities.css
@@ -39,6 +39,9 @@
 .security-tab__cell-fixed-ver,
 .security-tab__cell-policy {
     padding: 10px;
+    text-overflow: ellipsis;
+    max-width: 120px;
+    overflow: hidden;
 }
 
 .security-tab__cell-cve {

--- a/src/Common/Security/scanVulnerabilities.css
+++ b/src/Common/Security/scanVulnerabilities.css
@@ -39,9 +39,8 @@
 .security-tab__cell-fixed-ver,
 .security-tab__cell-policy {
     padding: 10px;
-    text-overflow: ellipsis;
     max-width: 120px;
-    overflow: hidden;
+    word-wrap: break-word;
 }
 
 .security-tab__cell-cve {


### PR DESCRIPTION
Put an upper limit on the `width` of the cells in the security vulnerability  scans table, to avoid overflowing of text and disturbing the cell alignment like in the below screenshot:

<img width="1440" alt="Screenshot_2023-11-06_at_5 55 04_PM" src="https://github.com/devtron-labs/devtron-fe-common-lib/assets/146105157/ee0171fa-bb23-48a8-ad8d-b3c86e651544">

After fix:

https://github.com/devtron-labs/devtron-fe-common-lib/assets/146105157/70d0da7f-00b0-41b7-a7d1-b868bf5e8d54


