### PR TITLE
fix: revert search working as regex search for logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "license": "ISC",
             "dependencies": {
                 "@types/react-dates": "^21.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -34,6 +34,7 @@ export const PATTERNS = {
     KUBERNETES_KEY_NAME: /^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$/,
     START_END_ALPHANUMERIC: /^([Az09].*[A-Za-z0-9])$|[A-Za-z0-9]$/,
     ALPHANUMERIC_WITH_SPECIAL_CHAR: /^[A-Za-z0-9._-]+$/, // allow alphanumeric,(.) ,(-),(_)
+    ESCAPED_CHARACTERS: /[.*+?^${}()|[\]\\]/g,
 }
 
 export const URLS = {

--- a/src/Shared/Helpers.tsx
+++ b/src/Shared/Helpers.tsx
@@ -18,7 +18,15 @@
 import { useEffect, useRef, useState, ReactElement } from 'react'
 import Tippy from '@tippyjs/react'
 import moment from 'moment'
-import { handleUTCTime, mapByKey, MaterialInfo, shallowEqual, SortingOrder, ZERO_TIME_STRING } from '../Common'
+import {
+    handleUTCTime,
+    mapByKey,
+    MaterialInfo,
+    PATTERNS,
+    shallowEqual,
+    SortingOrder,
+    ZERO_TIME_STRING,
+} from '../Common'
 import {
     AggregationKeys,
     GitTriggers,
@@ -54,7 +62,8 @@ interface HighlightSearchTextProps {
     highlightClasses?: string
 }
 
-// Disabling default export since this is a helper function and we would have to export a lot of functions in future.
+export const escapeRegExp = (text: string): string => text.replace(PATTERNS.ESCAPED_CHARACTERS, '\\$&')
+
 export const highlightSearchText = ({ searchText, text, highlightClasses }: HighlightSearchTextProps): string => {
     if (!searchText) {
         return text


### PR DESCRIPTION
# Description
This PR fixes the bug wherein logs renderer we replaced the matched portion of logs with searchText itself instead of match.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
