### PR TITLE
feat: add support for content based editor height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.2.13",
+    "version": "0.2.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "0.2.13",
+            "version": "0.2.14",
             "license": "ISC",
             "dependencies": {
                 "@types/react-dates": "^21.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.2.13",
+    "version": "0.2.14",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Common/CodeEditor/CodeEditor.tsx
+++ b/src/Common/CodeEditor/CodeEditor.tsx
@@ -87,7 +87,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
         cleanData = false,
         onBlur,
         onFocus,
-        adjustEditorHeightToContent,
+        adjustEditorHeightToContent = false,
     }) => {
         if (cleanData) {
             value = cleanKubeManifest(value)

--- a/src/Common/CodeEditor/types.ts
+++ b/src/Common/CodeEditor/types.ts
@@ -22,7 +22,7 @@ export interface InformationBarProps {
     children?: React.ReactNode
 }
 
-export interface CodeEditorInterface {
+interface CodeEditorBaseInterface {
     value?: string
     lineDecorationsWidth?: number
     responseType?: string
@@ -36,7 +36,6 @@ export interface CodeEditorInterface {
     readOnly?: boolean
     noParsing?: boolean
     inline?: boolean
-    height?: number | string
     shebang?: string | JSX.Element
     diffView?: boolean
     loading?: boolean
@@ -48,8 +47,19 @@ export interface CodeEditorInterface {
     isKubernetes?: boolean
     cleanData?: boolean
     chartVersion?: any
-    adjustEditorHeightToContent?: boolean
 }
+
+export type CodeEditorInterface = CodeEditorBaseInterface &
+    (
+        | {
+              adjustEditorHeightToContent?: boolean
+              height?: never
+          }
+        | {
+              adjustEditorHeightToContent?: never
+              height?: number | string
+          }
+    )
 
 export interface CodeEditorHeaderInterface {
     children?: any


### PR DESCRIPTION
# Description

Dynamically adjust the height of the code editor such that the scroll inside code editor does not appear. This feature can be enabled through the newly added prop `adjustEditorHeightToContent`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
