### PR TITLE
fix: filter users with no image approver access from user group data store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.2.6-beta-9",
+    "version": "0.2.6-beta-10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "0.2.6-beta-9",
+            "version": "0.2.6-beta-10",
             "license": "ISC",
             "dependencies": {
                 "@types/react-dates": "^21.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.2.6-beta-9",
+    "version": "0.2.6-beta-10",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Common/Common.service.ts
+++ b/src/Common/Common.service.ts
@@ -248,7 +248,9 @@ const getImageApprovalPolicyDetailsFromMaterialResult = (cdMaterialsResult): Ima
 
     const validGroups = userApprovalConfig.userGroups.map((group) => group.identifier)
 
-    const usersList = Object.keys(imageApprovalUsersInfo).filter((user) => user !== DefaultUserKey.system)
+    // Have moved from Object.keys(imageApprovalUsersInfo) to approvalUsers since backend is not filtering out the users without approval
+    // TODO: This check should be on BE. Need to remove this once BE is updated 
+    const usersList = approvalUsers.filter((user) => user !== DefaultUserKey.system)
     const groupIdentifierToUsersMap = usersList.reduce(
         (acc, user) => {
             const userGroups = imageApprovalUsersInfo[user] || []
@@ -277,6 +279,7 @@ const getImageApprovalPolicyDetailsFromMaterialResult = (cdMaterialsResult): Ima
                         (acc, user) => {
                             acc[user] = {
                                 email: user,
+                                // As of now it will always be true, but UI has handled it in a way that can support false as well
                                 hasAccess: approvalUsersMap[user] ?? false,
                             }
                             return acc


### PR DESCRIPTION
fix: filter users with no image approver access from user group data store