### PR TITLE
fix: remove unused error variable from catch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.2.23",
+    "version": "0.2.24",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "0.2.23",
+            "version": "0.2.24",
             "license": "ISC",
             "dependencies": {
                 "@types/react-dates": "^21.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "0.2.23",
+    "version": "0.2.24",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Shared/Components/Plugin/PluginList.tsx
+++ b/src/Shared/Components/Plugin/PluginList.tsx
@@ -58,7 +58,7 @@ const PluginList = ({
             )
 
             handleDataUpdateForPluginResponse(pluginDataResponse, true)
-        } catch (error) {
+        } catch {
             setHasError(true)
         } finally {
             setIsLoadingMorePlugins(false)


### PR DESCRIPTION
fix: remove unused error variable from catch