### PR TITLE
fix: timeout not registered a second time unless keyup event is fired

### DIFF
--- a/src/Common/Hooks/UseRegisterShortcut/UseRegisterShortcutProvider.tsx
+++ b/src/Common/Hooks/UseRegisterShortcut/UseRegisterShortcutProvider.tsx
@@ -31,7 +31,7 @@ const UseRegisterShortcutProvider = ({
 }: UseRegisterShortcutProviderType) => {
     const disableShortcutsRef = useRef<boolean>(false)
     const shortcutsRef = useRef<Record<string, ShortcutType>>({})
-    const keysDownRef = useRef<Set<string>>(new Set())
+    const keysDownRef = useRef<Set<Uppercase<string>>>(new Set())
     const keyDownTimeoutRef = useRef<ReturnType<typeof setTimeout>>(-1)
     const ignoredTags = ignoreTags ?? IGNORE_TAGS_FALLBACK
 
@@ -116,38 +116,37 @@ const UseRegisterShortcutProvider = ({
     }, [])
 
     const handleKeydownEvent = useCallback((event: KeyboardEvent) => {
-        if (keyDownTimeoutRef.current === -1) {
-            keyDownTimeoutRef.current = setTimeout(() => {
-                handleKeyupEvent()
-            }, shortcutTimeout ?? DEFAULT_TIMEOUT)
-        }
-
         if (preventDefault) {
             event.preventDefault()
         }
 
         if (
             ignoredTags.map((tag) => tag.toUpperCase()).indexOf((event.target as HTMLElement).tagName.toUpperCase()) >
-            -1
+                -1 ||
+            disableShortcutsRef.current
         ) {
             return
         }
 
-        if (!disableShortcutsRef.current) {
-            keysDownRef.current.add(event.key.toUpperCase())
+        keysDownRef.current.add(event.key.toUpperCase() as Uppercase<string>)
 
-            if (event.ctrlKey) {
-                keysDownRef.current.add('CONTROL')
-            }
-            if (event.metaKey) {
-                keysDownRef.current.add('META')
-            }
-            if (event.altKey) {
-                keysDownRef.current.add('ALT')
-            }
-            if (event.shiftKey) {
-                keysDownRef.current.add('SHIFT')
-            }
+        if (event.ctrlKey) {
+            keysDownRef.current.add('CONTROL')
+        }
+        if (event.metaKey) {
+            keysDownRef.current.add('META')
+        }
+        if (event.altKey) {
+            keysDownRef.current.add('ALT')
+        }
+        if (event.shiftKey) {
+            keysDownRef.current.add('SHIFT')
+        }
+
+        if (keyDownTimeoutRef.current === -1) {
+            keyDownTimeoutRef.current = setTimeout(() => {
+                handleKeyupEvent()
+            }, shortcutTimeout ?? DEFAULT_TIMEOUT)
         }
     }, [])
 


### PR DESCRIPTION
# Description

The first a shortcut timesout it works but consecutive timeouts don't happen unless we trigger a keyup.

Just moved the code that registers the timeout to the end of the handle key down event handler.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
