### PR TITLE
fix: logs renderer line number to accomodate till 99999 in single line and add padding for build in progress.

### DIFF
--- a/src/Shared/Components/CICDHistory/LogsRenderer.scss
+++ b/src/Shared/Components/CICDHistory/LogsRenderer.scss
@@ -64,7 +64,7 @@
         }
 
         &__log-item {
-            grid-template-columns: 34px auto;
+            grid-template-columns: 36px auto;
             &:hover {
                 background-color: var(--white-20);
             }

--- a/src/Shared/Components/CICDHistory/TriggerDetails.tsx
+++ b/src/Shared/Components/CICDHistory/TriggerDetails.tsx
@@ -146,7 +146,7 @@ const ProgressingStatus = memo(({ stage, type, label = 'In progress' }: Progress
 
     return (
         <>
-            <div className="flex dc__gap-8 left">
+            <div className="flex dc__gap-8 left py-8">
                 <div className="dc__min-width-fit-content">
                     <div className="fs-13 fw-6 flex left inprogress-status-color">{label}</div>
                 </div>
@@ -242,7 +242,7 @@ const CurrentStatus = memo(
 
             if (executionInfo.currentStatus === WorkflowStageStatusType.UNKNOWN) {
                 return (
-                    <div className="flex dc__gap-8 left pt-12">
+                    <div className="flex dc__gap-8 left py-8">
                         <span className="cn-9 fs-13 fw-6 lh-20">Unknown status</span>
 
                         {type === HistoryComponentType.CI && artifact && (


### PR DESCRIPTION
# Description
fix: logs renderer line number to accomodate till 99999 in single line and add padding for build in progress

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Dev test

## Checklist

- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
