### PR TITLE
chore(version): bump version to 1.17.0-pre-5 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.17.0-pre-4",
+    "version": "1.17.0-pre-5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "1.17.0-pre-4",
+            "version": "1.17.0-pre-5",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.17.0-pre-4",
+    "version": "1.17.0-pre-5",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
chore(version): bump version to 1.17.0-pre-5 in package.json and package-lock.json