### PR TITLE
feat: add global API timeout setting and enhance force delete confirmation modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "1.20.2",
+            "version": "1.20.3",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Common/API/CoreAPI.ts
+++ b/src/Common/API/CoreAPI.ts
@@ -278,6 +278,10 @@ class CoreAPI {
 
     trash = <T = any, K = object>(url: string, data?: K, options?: APIOptions): Promise<ResponseType<T>> =>
         this.fetchInTime<K>({ url, type: 'DELETE', data, options })
+
+    setGlobalAPITimeout = (timeout: number) => {
+        this.timeout = timeout || FALLBACK_REQUEST_TIMEOUT
+    }
 }
 
 export default CoreAPI

--- a/src/Common/API/index.ts
+++ b/src/Common/API/index.ts
@@ -23,7 +23,7 @@ const dashboardAPI = new CoreAPI({
     handleRedirectToLicenseActivation,
 })
 
-export const { post, put, patch, get, trash } = dashboardAPI
+export const { post, put, patch, get, trash, setGlobalAPITimeout } = dashboardAPI
 export { default as CoreAPI } from './CoreAPI'
 export { QueryClientProvider } from './QueryClientProvider'
 export * from './reactQueryHooks'

--- a/src/Shared/Components/ConfirmationModal/ForceDeleteConfirmationModal.tsx
+++ b/src/Shared/Components/ConfirmationModal/ForceDeleteConfirmationModal.tsx
@@ -23,6 +23,7 @@ export const ForceDeleteConfirmationModal = ({
     subtitle,
     onDelete,
     closeConfirmationModal,
+    isDeleting,
 }: ForceDeleteConfirmationProps) => {
     const renderSubtitle = () => (
         <>
@@ -43,6 +44,7 @@ export const ForceDeleteConfirmationModal = ({
                 primaryButtonConfig: {
                     text: 'Force Delete',
                     onClick: onDelete,
+                    isLoading: isDeleting,
                 },
             }}
             handleClose={closeConfirmationModal}

--- a/src/Shared/Components/ConfirmationModal/types.ts
+++ b/src/Shared/Components/ConfirmationModal/types.ts
@@ -187,7 +187,7 @@ export interface CannotDeleteModalProps
  * and `ConfirmationModalProps` to configure the force delete confirmation modal.
  */
 export interface ForceDeleteConfirmationProps
-    extends Partial<Pick<DeleteConfirmationModalProps, 'onDelete' | 'closeConfirmationModal'>>,
+    extends Partial<Pick<DeleteConfirmationModalProps, 'onDelete' | 'closeConfirmationModal' | 'isDeleting'>>,
         Partial<Pick<ConfirmationModalProps, 'title' | 'subtitle'>> {}
 
 export interface ConfirmationModalContextType {


### PR DESCRIPTION
# Description
This pull request introduces a new API timeout configuration feature and improves the force delete confirmation modal by adding a loading state to the delete button. The most important changes are grouped below by theme.

**API Timeout Configuration:**

* Added a `setGlobalAPITimeout` method to the `CoreAPI` class, allowing global adjustment of the API request timeout.
* Exported `setGlobalAPITimeout` from the API module for use throughout the application.

**Force Delete Confirmation Modal Improvements:**

* Updated `ForceDeleteConfirmationProps` to include an optional `isDeleting` property, enabling loading state management for the modal.
* Passed the `isDeleting` prop to the modal component and the primary button, displaying a loading indicator during deletion. [[1]](diffhunk://#diff-f8e3d9b9695c6595973559763c16a907001125c29f5cdd8a509823e146fb68bdR26) [[2]](diffhunk://#diff-f8e3d9b9695c6595973559763c16a907001125c29f5cdd8a509823e146fb68bdR47)
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
