### PR TITLE
feat: cost config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.20.3-pre-7",
+    "version": "1.20.3-pre-10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "1.20.3-pre-7",
+            "version": "1.20.3-pre-10",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.20.3-pre-7",
+    "version": "1.20.3-pre-10",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Common/Common.service.ts
+++ b/src/Common/Common.service.ts
@@ -651,6 +651,17 @@ export const getDetailedClusterList = async (
                 ...res
             }) => {
                 const costModuleInstallationStatus = costModuleConfig?.installationStatus || 'NotInstalled'
+                // Need to remove following keys from config if present: openCostServiceName, openCostServicePort, releaseName, namespace
+                const sanitizedCostConfig = costModuleConfig?.config
+                    ? Object.fromEntries(
+                          Object.entries(costModuleConfig.config).filter(
+                              ([key]) =>
+                                  !['openCostServiceName', 'openCostServicePort', 'releaseName', 'namespace'].includes(
+                                      key,
+                                  ),
+                          ),
+                      )
+                    : undefined
 
                 return {
                     ...res,
@@ -667,9 +678,7 @@ export const getDetailedClusterList = async (
                     status: clusterStatus,
                     costModuleConfig: {
                         enabled: costModuleConfig?.enabled || false,
-                        config: {
-                            cloudProviderApiKey: costModuleConfig.config?.cloudProviderApiKey || '',
-                        },
+                        config: sanitizedCostConfig,
                         installationStatus: costModuleInstallationStatus,
                         ...(costModuleInstallationStatus === 'Failed'
                             ? {

--- a/src/Common/Common.service.ts
+++ b/src/Common/Common.service.ts
@@ -55,7 +55,6 @@ import {
     AppsGroupedByProjectsType,
     ClusterDetailListType,
     ClusterDetailDTO,
-    ClusterCostModuleConfigDTO,
 } from './Types'
 import { ApiResourceType, STAGE_MAP } from '../Pages'
 import { RefVariableType, VariableTypeFormat } from './CIPipeline.Types'
@@ -651,27 +650,19 @@ export const getDetailedClusterList = async (
                 costModuleConfig,
                 ...res
             }) => {
-                const baseCostModuleConfig: ClusterCostModuleConfigDTO = costModuleConfig?.enabled
-                    ? {
-                          enabled: true,
-                          config: {
-                              cloudProviderApiKey: costModuleConfig.config?.cloudProviderApiKey || '',
-                          },
-                      }
-                    : {
-                          enabled: false,
-                      }
-
                 const costModuleInstallationStatus = costModuleConfig?.installationStatus || 'NotInstalled'
 
                 const costModuleData: ClusterDetailListType['costModuleConfig'] = {
-                    ...baseCostModuleConfig,
+                    enabled: costModuleConfig?.enabled || false,
+                    config: {
+                        cloudProviderApiKey: costModuleConfig.config?.cloudProviderApiKey || '',
+                    },
                     installationStatus: costModuleConfig?.installationStatus || 'NotInstalled',
                     ...(costModuleInstallationStatus === 'Failed'
                         ? {
                               installationError: costModuleConfig?.installationError || 'Some error occurred',
                           }
-                        : {})
+                        : {}),
                 }
 
                 return {

--- a/src/Common/Common.service.ts
+++ b/src/Common/Common.service.ts
@@ -652,19 +652,6 @@ export const getDetailedClusterList = async (
             }) => {
                 const costModuleInstallationStatus = costModuleConfig?.installationStatus || 'NotInstalled'
 
-                const costModuleData: ClusterDetailListType['costModuleConfig'] = {
-                    enabled: costModuleConfig?.enabled || false,
-                    config: {
-                        cloudProviderApiKey: costModuleConfig.config?.cloudProviderApiKey || '',
-                    },
-                    installationStatus: costModuleConfig?.installationStatus || 'NotInstalled',
-                    ...(costModuleInstallationStatus === 'Failed'
-                        ? {
-                              installationError: costModuleConfig?.installationError || 'Some error occurred',
-                          }
-                        : {}),
-                }
-
                 return {
                     ...res,
                     clusterId: id,
@@ -678,7 +665,18 @@ export const getDetailedClusterList = async (
                           }
                         : null,
                     status: clusterStatus,
-                    costModuleConfig: costModuleData,
+                    costModuleConfig: {
+                        enabled: costModuleConfig?.enabled || false,
+                        config: {
+                            cloudProviderApiKey: costModuleConfig.config?.cloudProviderApiKey || '',
+                        },
+                        installationStatus: costModuleInstallationStatus,
+                        ...(costModuleInstallationStatus === 'Failed'
+                            ? {
+                                  installationError: costModuleConfig?.installationError || 'Some error occurred',
+                              }
+                            : {}),
+                    } satisfies ClusterDetailListType['costModuleConfig'],
                 }
             },
         )

--- a/src/Common/Types.ts
+++ b/src/Common/Types.ts
@@ -1118,7 +1118,7 @@ export type EnvironmentsGroupedByClustersType = {
     envList: EnvironmentType[]
 }[]
 
-export type ClusterCostModuleConfigDTO =
+export type ClusterCostModuleConfigPayload =
     | {
           enabled: true
           config?: {
@@ -1130,7 +1130,7 @@ export type ClusterCostModuleConfigDTO =
           config?: never
       }
 
-type ClusterCostModuleDetailsDTO = ClusterCostModuleConfigDTO & {
+interface ClusterCostModuleDetailsDTO extends Pick<ClusterCostModuleConfigPayload, 'enabled' | 'config'> {
     // Note that these status are independent of `enabled` flag
     // e.g. cost module can be disabled but still in `Success` state
     installationStatus: 'Success' | 'Installing' | 'NotInstalled' | 'Failed'

--- a/src/Common/Types.ts
+++ b/src/Common/Types.ts
@@ -1118,6 +1118,25 @@ export type EnvironmentsGroupedByClustersType = {
     envList: EnvironmentType[]
 }[]
 
+export type ClusterCostModuleConfigDTO =
+    | {
+          enabled: true
+          config?: {
+              cloudProviderApiKey: string
+          }
+      }
+    | {
+          enabled: false
+          config?: never
+      }
+
+type ClusterCostModuleDetailsDTO = ClusterCostModuleConfigDTO & {
+    // Note that these status are independent of `enabled` flag
+    // e.g. cost module can be disabled but still in `Success` state
+    installationStatus: 'Success' | 'Installing' | 'NotInstalled' | 'Failed'
+    installationError?: string
+}
+
 export interface ClusterDetailDTO {
     category: ClusterEnvironmentCategoryType
     cluster_name: string
@@ -1133,6 +1152,7 @@ export interface ClusterDetailDTO {
     proxyUrl: string
     toConnectWithSSHTunnel: boolean
     clusterStatus: ClusterStatusType
+    costModuleConfig: ClusterCostModuleDetailsDTO
 }
 
 export interface ClusterDetailListType

--- a/src/Common/Types.ts
+++ b/src/Common/Types.ts
@@ -1121,9 +1121,7 @@ export type EnvironmentsGroupedByClustersType = {
 export type ClusterCostModuleConfigPayload =
     | {
           enabled: true
-          config?: {
-              cloudProviderApiKey: string
-          }
+          config?: Record<string, any>
       }
     | {
           enabled: false
@@ -1133,7 +1131,7 @@ export type ClusterCostModuleConfigPayload =
 interface ClusterCostModuleDetailsDTO extends Pick<ClusterCostModuleConfigPayload, 'enabled' | 'config'> {
     // Note that these status are independent of `enabled` flag
     // e.g. cost module can be disabled but still in `Success` state
-    installationStatus: 'Success' | 'Installing' | 'NotInstalled' | 'Failed'
+    installationStatus: 'Success' | 'Installing' | 'Upgrading' | 'NotInstalled' | 'Failed'
     installationError?: string
 }
 

--- a/src/Pages-Devtron-2.0/CostVisibility/Shared/constants.tsx
+++ b/src/Pages-Devtron-2.0/CostVisibility/Shared/constants.tsx
@@ -1,0 +1,27 @@
+import { IconName } from '@Shared/Components'
+
+import { ClusterProviderType } from './types'
+
+export const CLUSTER_PROVIDER_TO_ICON_NAME: Record<ClusterProviderType, IconName | null> = {
+    AWS: 'ic-aws',
+    OTC: 'ic-otc-cloud',
+    Azure: 'ic-azure',
+    GCP: 'ic-google-cloud',
+    Alibaba: 'ic-alibaba',
+    Oracle: 'ic-oracle-cloud',
+    Scaleway: null,
+    DigitalOcean: null,
+    Unknown: null,
+}
+
+export const CLUSTER_PROVIDER_TO_LABEL: Record<ClusterProviderType, string> = {
+    AWS: 'AWS',
+    OTC: 'OTC',
+    Azure: 'Azure',
+    GCP: 'GCP',
+    Alibaba: 'Alibaba',
+    Oracle: 'Oracle',
+    Scaleway: 'Scaleway',
+    DigitalOcean: 'DigitalOcean',
+    Unknown: 'N/A',
+}

--- a/src/Pages-Devtron-2.0/CostVisibility/Shared/index.ts
+++ b/src/Pages-Devtron-2.0/CostVisibility/Shared/index.ts
@@ -1,1 +1,2 @@
+export * from './constants'
 export * from './types'

--- a/src/Pages-Devtron-2.0/CostVisibility/Shared/types.ts
+++ b/src/Pages-Devtron-2.0/CostVisibility/Shared/types.ts
@@ -1,3 +1,7 @@
+import { ReactNode } from 'react'
+
+import { ClusterDetailListType } from '@Common/Types'
+
 export enum CostBreakdownViewType {
     CLUSTERS = 'clusters',
     ENVIRONMENTS = 'environments',
@@ -10,3 +14,28 @@ export enum CostBreakdownItemViewParamsType {
     VIEW = 'view',
     DETAIL = 'detail',
 }
+
+type RenderClusterFormParamsType = {
+    clusterDetails: ClusterDetailListType
+    handleClose: () => void
+    handleSuccess: () => void
+}
+
+export interface CostVisibilityRenderContextType {
+    renderClusterForm: (params: RenderClusterFormParamsType) => JSX.Element
+}
+
+export interface CostVisibilityRenderProviderProps extends CostVisibilityRenderContextType {
+    children: ReactNode
+}
+
+export type ClusterProviderType =
+    | 'AWS'
+    | 'GCP'
+    | 'Azure'
+    | 'Alibaba'
+    | 'Scaleway'
+    | 'Oracle'
+    | 'OTC'
+    | 'DigitalOcean'
+    | 'Unknown'

--- a/src/Pages-Devtron-2.0/CostVisibility/Shared/types.ts
+++ b/src/Pages-Devtron-2.0/CostVisibility/Shared/types.ts
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { RJSFFormSchema } from '@Common/RJSF'
 import { ClusterDetailListType } from '@Common/Types'
 
 export enum CostBreakdownViewType {
@@ -39,3 +40,8 @@ export type ClusterProviderType =
     | 'OTC'
     | 'DigitalOcean'
     | 'Unknown'
+
+export interface ClusterProviderDetailsType {
+    clusterProvider: ClusterProviderType
+    costModuleSchema: RJSFFormSchema
+}

--- a/src/Shared/Components/PrometheusConfigurations/PrometheusConfigCard.tsx
+++ b/src/Shared/Components/PrometheusConfigurations/PrometheusConfigCard.tsx
@@ -1,18 +1,14 @@
-import { noop } from '@Common/Helper'
 import RadioGroup from '@Common/RadioGroup'
 import RadioGroupItem from '@Common/RadioGroupItem'
 import { AuthenticationType } from '@Shared/types'
 
-import { ButtonVariantType } from '../Button'
 import { CustomInput, PasswordField } from '../CustomInput'
-import { Icon } from '../Icon'
 import { InfoBlock } from '../InfoBlock'
 import { Textarea } from '../Textarea'
 import { PromoetheusConfigProps } from './types'
 
 const PromoetheusConfigCard = ({
     prometheusConfig,
-    isCostPrometheus,
     handleOnChange,
     onPrometheusAuthTypeChange,
 }: PromoetheusConfigProps) => {
@@ -26,19 +22,6 @@ const PromoetheusConfigCard = ({
                     Devtron uses prometheus to store and track cluster metrics
                 </span>
             </div>
-            {isCostPrometheus && (
-                <InfoBlock
-                    variant="help"
-                    description="Reuse Prometheus configuration from Application Monitoring"
-                    buttonProps={{
-                        dataTestId: 'autofill-prometheus',
-                        text: 'Autofill',
-                        onClick: noop, // TODO: Update onClick when cost prometheus is supported
-                        variant: ButtonVariantType.text,
-                        startIcon: <Icon name="ic-magic-wand" color={null} />,
-                    }}
-                />
-            )}
             {(userName.error || password.error || endpoint.error) && (
                 <InfoBlock
                     variant="error"

--- a/src/Shared/Components/PrometheusConfigurations/types.ts
+++ b/src/Shared/Components/PrometheusConfigurations/types.ts
@@ -20,5 +20,4 @@ export interface PromoetheusConfigProps {
     prometheusConfig: PromoetheusConfig
     handleOnChange: (event: SyntheticEvent) => void
     onPrometheusAuthTypeChange: (event: SyntheticEvent) => void
-    isCostPrometheus?: boolean
 }


### PR DESCRIPTION
# Description
This pull request introduces enhancements and refactoring to the cost visibility and cluster management features, focusing on improved type safety, extensibility, and clarity in data handling. The main changes include new type definitions for cluster cost module configuration, updates to how cluster details are constructed and returned, and the addition of shared constants and types for cost visibility. Minor cleanups and formatting improvements are also included.

### Cluster Cost Module Enhancements

* Added new types to describe cluster cost module configuration and installation status, including error handling, in `src/Common/Types.ts`. The `ClusterDetailDTO` interface now includes a `costModuleConfig` property for richer cost module metadata. [[1]](diffhunk://#diff-a9ac7aca6644994fc547ab75e72a243eedcb8e1f8f27d947836cfd40afef8bbdR1121-R1139) [[2]](diffhunk://#diff-a9ac7aca6644994fc547ab75e72a243eedcb8e1f8f27d947836cfd40afef8bbdR1155)
* Refactored `getDetailedClusterList` in `src/Common/Common.service.ts` to build and return detailed cost module configuration, including installation status and error messages, for each cluster. [[1]](diffhunk://#diff-8929701bb436752b9a5ab35e1b513b2bf42e48fe20205d78b316777d9bf8ce87L637-R637) [[2]](diffhunk://#diff-8929701bb436752b9a5ab35e1b513b2bf42e48fe20205d78b316777d9bf8ce87R650-R668) [[3]](diffhunk://#diff-8929701bb436752b9a5ab35e1b513b2bf42e48fe20205d78b316777d9bf8ce87L664-R683)

### Cost Visibility Shared Utilities

* Added new shared constants mapping cluster provider types to icon names and labels in `src/Pages-Devtron-2.0/CostVisibility/Shared/constants.tsx`, and exported them for reuse. [[1]](diffhunk://#diff-dfb7072e416adc11c6f09b8aea571ccbe8d7c3ad7a73b50123de44b548bf9498R1-R27) [[2]](diffhunk://#diff-e2f21f951b279ae0f50ff58fc28b90c54954963fd23badec3a93d351542e5252R1)
* Defined and exported new shared types for cost visibility context, cluster provider types, and render parameters in `src/Pages-Devtron-2.0/CostVisibility/Shared/types.ts`. [[1]](diffhunk://#diff-d265a671dcbb87d7ac6672cce4b07fe635c8cc50f2c237206be2a74c0e3968baR1-R4) [[2]](diffhunk://#diff-d265a671dcbb87d7ac6672cce4b07fe635c8cc50f2c237206be2a74c0e3968baR17-R41)

### Code Cleanup and Formatting

* Removed unused props and related code from `PromoetheusConfigCard` and its type definition, simplifying the component and its interface. [[1]](diffhunk://#diff-9c01d78210acb287c48963c59f608cd68deda058ad73e0f06d65c705fd1da9c7L1-L15) [[2]](diffhunk://#diff-9c01d78210acb287c48963c59f608cd68deda058ad73e0f06d65c705fd1da9c7L29-L41) [[3]](diffhunk://#diff-fd9076dabdc4eccf42a70eafe8f3b92e730c41abe30d2d61e352ff5d68ed60c5L23)
* Minor formatting improvements and removal of unnecessary blank lines in `src/Common/Common.service.ts`. [[1]](diffhunk://#diff-8929701bb436752b9a5ab35e1b513b2bf42e48fe20205d78b316777d9bf8ce87L573) [[2]](diffhunk://#diff-8929701bb436752b9a5ab35e1b513b2bf42e48fe20205d78b316777d9bf8ce87L589)

### Approval Logic Refactoring

* Improved clarity in approval logic by splitting conditions for `isConsumedNonApprovedImage` and streamlining the configuration check in `processCDMaterialServiceResponse` within `src/Common/Common.service.ts`. [[1]](diffhunk://#diff-8929701bb436752b9a5ab35e1b513b2bf42e48fe20205d78b316777d9bf8ce87L144-R145) [[2]](diffhunk://#diff-8929701bb436752b9a5ab35e1b513b2bf42e48fe20205d78b316777d9bf8ce87L352-R353)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
