### PR TITLE
feat: proxy host

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.20.3-pre-10",
+    "version": "1.20.3-pre-11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "1.20.3-pre-10",
+            "version": "1.20.3-pre-11",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.20.3-pre-10",
+    "version": "1.20.3-pre-11",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Common/API/CoreAPI.ts
+++ b/src/Common/API/CoreAPI.ts
@@ -49,6 +49,7 @@ class CoreAPI {
         preventLicenseRedirect = false,
         shouldParseServerErrorForUnauthorizedUser = false,
         isMultipartRequest,
+        isProxyHost = false,
     }: FetchAPIParamsType<K>): Promise<ResponseType> => {
         const options: RequestInit = {
             method: type,
@@ -58,7 +59,7 @@ class CoreAPI {
         // eslint-disable-next-line dot-notation
         options['credentials'] = 'include' as RequestCredentials
         return fetch(
-            `${this.host}/${url}`,
+            `${isProxyHost ? '/proxy' : this.host}/${url}`,
             !isMultipartRequest
                 ? options
                 : ({

--- a/src/Common/API/types.ts
+++ b/src/Common/API/types.ts
@@ -40,5 +40,10 @@ export interface FetchInTimeParamsType<Data = object> {
 export interface FetchAPIParamsType<Data = object>
     extends Omit<FetchInTimeParamsType<Data>, 'options'>,
         Pick<APIOptions, 'preventAutoLogout' | 'preventLicenseRedirect' | 'shouldParseServerErrorForUnauthorizedUser'> {
+    /**
+     * @default false
+     * @description - If true, will override the default host (orchestrator or whatever defined initially in CoreAPI constructor) with the `proxy` host
+     */
+    isProxyHost?: boolean
     signal: AbortSignal
 }


### PR DESCRIPTION
# Description
This pull request introduces a new feature to the API request logic, allowing requests to be routed through a proxy host when needed. The main change is the addition of an `isProxyHost` parameter to the API functions, which modifies the request URL accordingly. This update is reflected in both the API interface and implementation.

**API enhancements:**

* Added an `isProxyHost` boolean parameter to the `FetchAPIParamsType` interface in `src/Common/API/types.ts`, allowing requests to specify if they should use the proxy host.
* Updated the `CoreAPI.fetch` method in `src/Common/API/CoreAPI.ts` to accept the new `isProxyHost` parameter and adjust the request URL to use `/proxy` when set to true. [[1]](diffhunk://#diff-4567818b64e97e6cc17a681b9b6d47b1b3fbf5e2b77dfeeb99a7c553d20f2759R52) [[2]](diffhunk://#diff-4567818b64e97e6cc17a681b9b6d47b1b3fbf5e2b77dfeeb99a7c553d20f2759L61-R62)

**Version update:**

* Bumped the package version in `package.json` from `1.20.3-pre-10` to `1.20.3-pre-11` to reflect the new feature addition.
