### PR TITLE
fix: update version to 1.20.5-pre-6 and add isProxyHost option to API interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.20.5-pre-5",
+    "version": "1.20.5-pre-6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "1.20.5-pre-5",
+            "version": "1.20.5-pre-6",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "1.20.5-pre-5",
+    "version": "1.20.5-pre-6",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Common/API/CoreAPI.ts
+++ b/src/Common/API/CoreAPI.ts
@@ -240,6 +240,7 @@ class CoreAPI {
                 preventLicenseRedirect: options?.preventLicenseRedirect || false,
                 shouldParseServerErrorForUnauthorizedUser: options?.shouldParseServerErrorForUnauthorizedUser,
                 isMultipartRequest,
+                isProxyHost: options?.isProxyHost || false,
             }),
             timeoutPromise,
         ]).catch((err) => {

--- a/src/Common/API/types.ts
+++ b/src/Common/API/types.ts
@@ -39,11 +39,9 @@ export interface FetchInTimeParamsType<Data = object> {
 
 export interface FetchAPIParamsType<Data = object>
     extends Omit<FetchInTimeParamsType<Data>, 'options'>,
-        Pick<APIOptions, 'preventAutoLogout' | 'preventLicenseRedirect' | 'shouldParseServerErrorForUnauthorizedUser'> {
-    /**
-     * @default false
-     * @description - If true, will override the default host (orchestrator or whatever defined initially in CoreAPI constructor) with the `proxy` host
-     */
-    isProxyHost?: boolean
+        Pick<
+            APIOptions,
+            'preventAutoLogout' | 'preventLicenseRedirect' | 'shouldParseServerErrorForUnauthorizedUser' | 'isProxyHost'
+        > {
     signal: AbortSignal
 }

--- a/src/Common/Types.ts
+++ b/src/Common/Types.ts
@@ -79,6 +79,11 @@ export interface APIOptions {
      * @default false
      */
     shouldParseServerErrorForUnauthorizedUser?: boolean
+    /**
+     * @default false
+     * @description - If true, will override the default host (orchestrator or whatever defined initially in CoreAPI constructor) with the `proxy` host
+     */
+    isProxyHost?: boolean
 }
 
 export interface OptionType<T = string, K = string> {


### PR DESCRIPTION
fix: update version to 1.20.5-pre-6 and add isProxyHost option to API interfaces