### PR TITLE
fix: update pre/beta release workflow logic

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,36 +1,47 @@
 name: Node.js Package
 
 on:
-  release:
-    types: [created]
+    release:
+        types: [created]
 
 jobs:
-  build-and-publish:
-    name: Build and Publish to NPM Registry
+    build-and-publish:
+        name: Build and Publish to NPM Registry
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org/'
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+                  registry-url: 'https://registry.npmjs.org/'
 
-      - name: Install dependencies
-        run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Execute test cases
-        run: npm test
+            - name: Execute test cases
+              run: npm test
 
-      - name: Build Lib
-        run: npm run build-lib
+            - name: Build Lib
+              run: npm run build-lib
 
-      - name: Publish to NPM Registry
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: Publish to NPM Registry
+              run: |
+                  VERSION=$(node -p "require('./package.json').version")
+                  
+                  if [[ $VERSION == *"-beta."* ]]; then
+                    npm publish --access public --tag beta
+
+                  elif [[ $VERSION == *"-"* ]]; then
+                    npm publish --access public --tag next
+
+                  else
+                    npm publish --access public
+                  fi
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description
This pull request updates the NPM publishing workflow in `.github/workflows/release-package.yml` to support publishing prerelease versions with appropriate tags. Now, beta versions are published with the `beta` tag, other prereleases with the `next` tag, and regular releases without a tag.

**Publishing automation improvements:**

* Updated the NPM publish step to detect the version from `package.json` and automatically assign the correct tag (`beta`, `next`, or none) based on the version string.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
