### PR TITLE
fix: user export list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "4.0.5",
+    "version": "4.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@devtron-labs/devtron-fe-common-lib",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devtron-labs/devtron-fe-common-lib",
-    "version": "4.0.5",
+    "version": "4.0.6",
     "description": "Supporting common component library",
     "type": "module",
     "main": "dist/index.js",

--- a/src/Shared/Components/ExportToCsv/ExportToCsv.tsx
+++ b/src/Shared/Components/ExportToCsv/ExportToCsv.tsx
@@ -24,12 +24,13 @@ const ExportToCsv = <HeaderItemType extends string>({
     downloadRequestId,
 }: ExportToCsvProps<HeaderItemType>) => {
     const csvRef = useRef(null)
-    const abortControllerRef = useRef<AbortController>(new AbortController())
+    const abortControllerRef = useRef<AbortController>(null)
 
     const [dataToExport, setDataToExport] = useState<Awaited<ReturnType<typeof apiPromise>>>([])
     const [confirmationModalType, setConfirmationModalType] = useState<'default' | 'custom' | null>(null)
     const [isLoading, setIsLoading] = useState(false)
     const [dataFetchError, setDataFetchError] = useState<ServerErrors>(null)
+    const [pendingDownload, setPendingDownload] = useState(false)
 
     const handleInitiateDownload = async () => {
         if (disabled) {
@@ -41,8 +42,7 @@ const ExportToCsv = <HeaderItemType extends string>({
             setDataFetchError(null)
             const data = await apiPromise({ signal: abortControllerRef.current.signal })
             setDataToExport(data)
-
-            csvRef.current?.link?.click()
+            setPendingDownload(true)
         } catch (error) {
             if (!getIsRequestAborted(error)) {
                 showError(error)
@@ -64,12 +64,12 @@ const ExportToCsv = <HeaderItemType extends string>({
         }
     }
 
-    useEffect(
-        () => () => {
-            abortControllerRef.current.abort()
-        },
-        [],
-    )
+    useEffect(() => {
+        abortControllerRef.current = new AbortController()
+        return () => {
+            abortControllerRef.current?.abort()
+        }
+    }, [])
 
     useEffect(() => {
         if (!isNullOrUndefined(downloadRequestId)) {
@@ -77,6 +77,13 @@ const ExportToCsv = <HeaderItemType extends string>({
             handleExportButtonClick()
         }
     }, [downloadRequestId])
+
+    useEffect(() => {
+        if (pendingDownload) {
+            csvRef.current?.link?.click()
+            setPendingDownload(false)
+        }
+    }, [pendingDownload])
 
     const handleCancelRequest = () => {
         abortControllerRef.current.abort()


### PR DESCRIPTION
This pull request updates the `ExportToCsv` component to improve download handling and abort controller management, and bumps the package version. The most significant changes are improvements to how CSV downloads are triggered and how abort controllers are initialized and cleaned up.

**Export/download flow improvements:**

* Changed the download trigger to set a `pendingDownload` state, which is then handled by a new `useEffect` hook. This ensures the CSV download is initiated only after data is fetched and state is updated, improving reliability. [[1]](diffhunk://#diff-3593dc53bfd1538c6a6b4aaddc00dc014d3a66f0aaeeaff428a606433d962d09L44-R45) [[2]](diffhunk://#diff-3593dc53bfd1538c6a6b4aaddc00dc014d3a66f0aaeeaff428a606433d962d09R81-R87)

**Abort controller management:**

* Modified the initialization of `abortControllerRef` to start as `null` and set it up in a `useEffect`, ensuring a new `AbortController` is created on mount and properly aborted on unmount. This prevents potential memory leaks and ensures correct cancellation behavior. [[1]](diffhunk://#diff-3593dc53bfd1538c6a6b4aaddc00dc014d3a66f0aaeeaff428a606433d962d09L27-R33) [[2]](diffhunk://#diff-3593dc53bfd1538c6a6b4aaddc00dc014d3a66f0aaeeaff428a606433d962d09L67-R72)

**Package version update:**

* Bumped the package version in `package.json` from `4.0.5` to `4.0.6` to reflect these changes.